### PR TITLE
Fixed write data reset issue

### DIFF
--- a/TheThingsAPI.class.nut
+++ b/TheThingsAPI.class.nut
@@ -77,6 +77,8 @@ class TheThingsAPI {
     // Sends _data
     function write(cb = null) {
         local data = http.jsonencode(_data);
+	// Reset buffered data
+         _data = { values = [] };
 
         // Send the request and proces the response
         local request = http.post(_urlWrite, HEADERS_WRITE, data);
@@ -161,9 +163,6 @@ class TheThingsAPI {
     // Wraps a user callback (err, resp, data) and clears _data on success
     function _writeCallbackFactory(cb) {
         return _callbackFactory(function(err, resp, data) {
-            // Reset data on success
-            if (err == null) _data = { values = [] };
-
             // Invoke the user callback
             if (cb) cb(err, resp, data);
         }.bindenv(this));


### PR DESCRIPTION
The internal variable "_data" is not cleared every
time the write function is called. It is cleared on the user's
callback wrapper " _writeCallbackFactor". As a result, when the
application calls the write function twice before the first callback
has returned, the first values added with addVar became appended with
the values of the second addVar of the second write call. Then, on the
second write call, the values of the first and second write are sent
all together.
